### PR TITLE
fix: do not shift the top

### DIFF
--- a/src/Builder.mli
+++ b/src/Builder.mli
@@ -27,18 +27,24 @@ sig
     (** The type that embeds levels. *)
     type level
 
-    (** Smarter version of {!val:Syntax.Endo.shifted} that collapses multiple displacements. *)
+    (** Smarter version of {!val:Syntax.Endo.shifted} that collapses multiple displacements
+
+        @raise Invalid_argument When it attempts to shift the top level. *)
     val shifted : level -> shift -> level
 
     (** [top] is {!val:Syntax.Endo.top} *)
     val top : level
 
     (** [simplify l] collapses multiple displacements and removes useless ones.
-        (For example, shifted [top] is just [top].) *)
+        (For example, shifted [top] is just [top].)
+
+        @raise Invalid_argument When it attempts to shift the top level. *)
     val simplify : level -> level
 
     (** [dissect l] is a helper function that extract displacements from a level (if any).
-        If the level is displaced multiple times, all the displacements are composed into one. *)
+        If the level is displaced multiple times, all the displacements are composed into one.
+
+        @raise Invalid_argument When it attempts to shift the top level. *)
     val dissect : level -> level * shift option
   end
 

--- a/src/Theory.ml
+++ b/src/Theory.ml
@@ -1,26 +1,5 @@
-module type Param =
-sig
-  module Shift : Shift.S
-  type var
-  val equal_var : var -> var -> bool
-end
-
-module type S =
-sig
-  type shift
-  type var
-  type level = (shift, var) Syntax.free
-  val equal : level -> level -> bool
-  val lt : level -> level -> bool
-  val leq : level -> level -> bool
-  val gt : level -> level -> bool
-  val geq : level -> level -> bool
-  val (=) : level -> level -> bool
-  val (<) : level -> level -> bool
-  val (<=) : level -> level -> bool
-  val (>) : level -> level -> bool
-  val (>=) : level -> level -> bool
-end
+module type Param = TheorySigs.Param
+module type S = TheorySigs.S
 
 module Make (P : Param) : S with type shift := P.Shift.t and type var := P.var =
 struct
@@ -52,9 +31,12 @@ struct
   let gt x y = lt y x
   let geq x y = leq y x
 
-  let (=) = equal
-  let (<) = lt
-  let (<=) = leq
-  let (>) = gt
-  let (>=) = geq
+  module Infix =
+  struct
+    let (=) = equal
+    let (<) = lt
+    let (<=) = leq
+    let (>) = gt
+    let (>=) = geq
+  end
 end

--- a/src/Theory.mli
+++ b/src/Theory.mli
@@ -1,58 +1,8 @@
 (** Parameters of universe level comparators. *)
-module type Param =
-sig
-  (** The displacement algebra. *)
-  module Shift : Shift.S
-
-  (** The type of level variables. *)
-  type var
-
-  (** [equal_var x y] checks whether two level variables [x] and [y] are the same. *)
-  val equal_var : var -> var -> bool
-end
+module type Param = TheorySigs.Param
 
 (** The signature of universe level comparators. *)
-module type S =
-sig
-  (** The displacement algebra. *)
-  type shift
-
-  (** The type of level variables. *)
-  type var
-
-  (** The type of freely generated levels. *)
-  type level = (shift, var) Syntax.free
-
-  (** [equal l1 l2] checks whether [l1] and [l2] are the same universe level. *)
-  val equal : level -> level -> bool
-
-  (** [lt l1 l2] checks whether [l1] is strictly less than [l2]. Note that trichotomy fails for general universe levels. *)
-  val lt : level -> level -> bool
-
-  (** [leq l1 l2] checks whether [l1] is less than or equal to [l2]. Note that trichotomy fails for general universe levels. *)
-  val leq : level -> level -> bool
-
-  (** [gt l1 l2] is [lt l2 l1]. *)
-  val gt : level -> level -> bool
-
-  (** [geq l1 l2] is [leq l2 l1]. *)
-  val geq : level -> level -> bool
-
-  (** Alias of {!val:equal}. *)
-  val (=) : level -> level -> bool
-
-  (** Alias of {!val:lt}. *)
-  val (<) : level -> level -> bool
-
-  (** Alias of {!val:leq}. *)
-  val (<=) : level -> level -> bool
-
-  (** Alias of {!val:gt}. *)
-  val (>) : level -> level -> bool
-
-  (** Alias of {!val:geq}. *)
-  val (>=) : level -> level -> bool
-end
+module type S = TheorySigs.S
 
 (** The universe level comparator. *)
 module Make (P : Param) : S with type shift := P.Shift.t and type var := P.var

--- a/src/TheorySigs.ml
+++ b/src/TheorySigs.ml
@@ -1,0 +1,65 @@
+(** Parameters of universe level comparators. *)
+module type Param =
+sig
+  (** The displacement algebra. *)
+  module Shift : Shift.S
+
+  (** The type of level variables. *)
+  type var
+
+  (** [equal_var x y] checks whether two level variables [x] and [y] are the same. *)
+  val equal_var : var -> var -> bool
+end
+
+(** The signature of universe level comparators. *)
+module type S =
+sig
+  (** The displacement algebra. *)
+  type shift
+
+  (** The type of level variables. *)
+  type var
+
+  (** The type of freely generated levels. *)
+  type level = (shift, var) Syntax.free
+
+  (** [equal l1 l2] checks whether [l1] and [l2] are the same universe level.
+
+      @raise Invalid_argument When [l1] or [l2] is shifted top. *)
+  val equal : level -> level -> bool
+
+  (** [lt l1 l2] checks whether [l1] is strictly less than [l2]. Note that trichotomy fails for general universe levels.
+
+      @raise Invalid_argument When [l1] or [l2] is shifted top. *)
+  val lt : level -> level -> bool
+
+  (** [leq l1 l2] checks whether [l1] is less than or equal to [l2]. Note that trichotomy fails for general universe levels.
+
+      @raise Invalid_argument When [l1] or [l2] is shifted top. *)
+  val leq : level -> level -> bool
+
+  (** [gt l1 l2] is [lt l2 l1]. *)
+  val gt : level -> level -> bool
+
+  (** [geq l1 l2] is [leq l2 l1]. *)
+  val geq : level -> level -> bool
+
+  (** Infix notation. *)
+  module Infix :
+  sig
+    (** Alias of {!val:equal}. *)
+    val (=) : level -> level -> bool
+
+    (** Alias of {!val:lt}. *)
+    val (<) : level -> level -> bool
+
+    (** Alias of {!val:leq}. *)
+    val (<=) : level -> level -> bool
+
+    (** Alias of {!val:gt}. *)
+    val (>) : level -> level -> bool
+
+    (** Alias of {!val:geq}. *)
+    val (>=) : level -> level -> bool
+  end
+end


### PR DESCRIPTION
It seems better to ban the shifting of Top by a non-identity shift